### PR TITLE
Forward all comands only to turned on lights (e.g., colour change)

### DIFF
--- a/custom_components/relative_brightness_light_group/light.py
+++ b/custom_components/relative_brightness_light_group/light.py
@@ -144,6 +144,13 @@ class RelativeBrightnessLightGroup(LightGroup):
         else:
             # No lights on or other adjustments than brightness
 
+            entity_ids = [state.entity_id for state in lights_on]
+            #Check if there are currently lights turned on
+            #We need this, otherwise lights could never be turned on
+            if entity_ids:
+                #Change the target of the command only to the lights that are currently on
+                data[ATTR_ENTITY_ID] = entity_ids
+
             _LOGGER.debug("Forwarded turn_on command: %s", data)
 
             await self.hass.services.async_call(
@@ -153,3 +160,4 @@ class RelativeBrightnessLightGroup(LightGroup):
                 blocking=True,
                 context=self._context,
             )
+

--- a/custom_components/relative_brightness_light_group/manifest.json
+++ b/custom_components/relative_brightness_light_group/manifest.json
@@ -6,5 +6,5 @@
     "integration_type": "entity",
     "iot_class": "calculated", 
     "issue_tracker": "https://github.com/oscarb/relative-brightness-light-group/issues",
-    "version": "1.0.0"
+    "version": "1.0.1"
   }


### PR DESCRIPTION
When changing the colour (temperature) of the relative_brightness light group, this would turn on all members of the group. 

With this change, any other commands (like changing the colour) are forwarded only to the currently turned on lights. This implements the request of #1. 

No other behaviour changes. 